### PR TITLE
Clarification of Directory Structure

### DIFF
--- a/doc/MAP.md
+++ b/doc/MAP.md
@@ -57,11 +57,17 @@ And then, you can choose your map you want to use on the `Map > Active map`
 If you want, you can host your own map tiles collections, your host must follow the files structure:
 
 ```
-├── <your-host>
-│   ├── <map-collection>
-│   │   └──  Tiles
-│   │       └── ...
-│   │   ├── TileMapInfo.json
+├── <localhost>
+│   ├── <ats>
+│   │   ├──  <latest>
+│   │   │   └──  Tiles
+│   │   │        └── ...
+│   │   │   ├── TileMapInfo.json
+│   ├── <ets2>
+│   │   ├──  <latest>
+│   │   │   └──  Tiles
+│   │   │        └── ...
+│   │   │   ├── TileMapInfo.json
 ```
 
 This project support the map tiles collection generated from this project


### PR DESCRIPTION
The original instructions for the folder structure ended up causing an error about `Map config NOT FOUND`, so I did a little testing of the original server used for the map tiles and found out why.

This edit to the `MAP.md` is just a quick edit to clarify it and hopefully make it a bit easier to understand for people that wish to host their own.