### PR TITLE
Add support for iOS full screen web clip, clean up grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ And that's it :D
 
 > Note: Your mobile device AND your PC need to be on the same network
 
-> Tip: On an iOS device, you can add the webpage to your home screen like an app! When on the page, tap the Share button, navigate to "Add to home screen," wait ~2 seconds for it to verify, and confirm it. It will go to your home screen and show your neat dashboard shortcut!
+> Tip: On an iOS device, you can add the webpage to your home screen like an app! When on the page, tap the Share button, navigate to "Add to home screen," wait ~2 seconds for it to verify, and confirm it. It will go to your home screen and show your neat dashboard shortcut! On Android, you can do the same by tapping the three dot on the top right part of the screen, and tapping "Add to home screen."
 
 If you want to use another port, you can change it in the configuration file.
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ If you're interested, check the [`JAGFx/ts-map`](https://github.com/JAGFx/ts-map
 
 More information on the [Map](./doc/MAP.md) readme
 
-> Many thanks to [TwinDragon](https://github.com/TwinDragon) for maintaining a map tiles collection up to date for each new game version
+> Many thanks to [TwinDragon](https://github.com/TwinDragon) for maintaining an up to date map tile collection with each new version
 
 ### Offline
 
-See the [SCS_Map_Tiles](https://github.com/TwinDragon/SCS_Map_Tiles#supported-maps) repository for supported game, versions available and download links
+See the [SCS_Map_Tiles](https://github.com/TwinDragon/SCS_Map_Tiles#supported-maps) repository for supported games, versions available and download links
 
 ## Internationalization
 
@@ -83,16 +83,16 @@ Install *[scs-sdk-plugin](https://github.com/RenCloud/scs-sdk-plugin)* by RenClo
 
 - Download the supported version zip `v1.11` at
   the [release](https://github.com/RenCloud/scs-sdk-plugin/releases/download/V.1.11/release_v_1_11.zip) page
-- Extract the DLL file into your game folder like `C:\you-game-path\bin\win_x64\plugins\`
-
+- Extract the DLL file into your game folder like `C:\your-game-path\bin\win_x64\plugins\`
+-- Note: If you own the Steam version, you can quickly access the game folder by right-clicking the game in your Steam library, hovering above 'Manage,' and clicking 'Browse local files.' You can proceed to navigate to bin > win_x64 > plugins.
 ### Installation
 
-You can use this dashboard without build anything.
+You can use this dashboard without building anything.
 
 You can download the `*.tar.gz` archive from the [release](https://github.com/JAGFx/ets2-dashboard-skin/releases/latest)
 page.
 
-Extract this archive and run the `ets2-dashboard-skin_vX.X.X.exe`. That's it ! 
+Extract this archive and run the `ets2-dashboard-skin_vX.X.X.exe`. That's it! 
 
 > Note: You need to start the game to see the dashboard
 
@@ -109,37 +109,37 @@ And that's it :D
    how [here](https://www.whatismybrowser.com/detect/what-is-my-local-ip-address))
 2. Open a web browser on your mobile device
 3. Access to the dashboard on your mobile: `http://<YOUR_LOCAL_IP>:3000` (e.g. `http://192.168.1.42:3000`)
-4. And voilà ! You can enable / disable the fullscreen on tap on the dashboard
+4. And voilà! You can enable / disable the fullscreen on tap on the dashboard
 
 > Note: Your mobile device AND your PC need to be on the same network
 
-> Tip: You can save a shortcut on your home screen to use it as an app like.
+> Tip: On an iOS device, you can add the webpage to your home screen like an app! When on the page, tap the Share button, navigate to "Add to home screen," wait ~2 seconds for it to verify, and confirm it. It will go to your home screen and show your neat dashboard shortcut!
 
-If you want to use another port, change it on the configuration file.
+If you want to use another port, you can change it in the configuration file.
 
-## Breaking change
+## Breaking changelog
 
 See the [BREAKING_CHANGES.md](doc/BREAKING_CHANGES.md) readme
 
-## Translation change
+## Translation changelog
 
 See the [TRANSLATION_CHANGES.md](doc/TRANSLATION_CHANGES.md) readme
 
-## Know issues
+## Known issues
 
 If you found an issue, please see the [KNOW_ISSUES.md](doc/KNOW_ISSUES.md). Your issue may be already known.
 
 ## Features
 
-To see all features used into the dashboard, see the [FEATURES.md](doc/FEATURES.md).
+To see all features used into the dashboard, see the [FEATURES.md](doc/FEATURES.md) readme.
 
 ## Skins
 
-To know more about the skin integrated or how to add a new skin, see the [SKINS.md](doc/SKINS.md)
+To learn more about the skins integrated or how to add a new skin, see the [SKINS.md](doc/SKINS.md)
 
 ## Configuration
 
-To know more about the configuration, see the [CONFIG_SETTINGS.md](doc/CONFIG_SETTINGS.md)
+To learn more about the configuration, see the [CONFIG_SETTINGS.md](doc/CONFIG_SETTINGS.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -15,33 +15,31 @@
 ## About
 
 The idea with this repository is to update a collection of dashboard from
-the [Funbit repository](https://github.com/Funbit/ets2-telemetry-server) with the newest SCS SDK.
+the [Funbit repository](https://github.com/Funbit/ets2-telemetry-server) with the newest SCS SDK, as well as clean up the look and feel for a modern update to an already great app.
 
-And then, use a best way to maintain the different dashboard.
-
-The first to be rework are my own dashboard. In the future, all dashboard in the *Funbit repository* will be include
+The first skins to be reworked are my own dashboards. In the future, all dashboards in the *Funbit repository* will be included
 
 This project was based on the [TruckSim-Telemetry-Demo](https://github.com/kniffen/TruckSim-Telemetry-Demo)
 
 ![Screenshot](doc/screens/demo.gif)
 
-You can check also a review and installation guide made
+You can watch a tutorial on installing and a review
 by [Neranjana Wijesinghe](https://www.youtube.com/playlist?list=PLJONr1a8YX5Tyw-i49yk2jYTAFJJ5h7fw)
 
-## What's it ?
+## What is it?
 
-This is an web app who you can choose over dashboard skin (Custom or from other truck brand (DAF, Man, Mercedes,
-Renault, Scania or Volvo))
+This is an web app which you can use to choose a dashboard skin (Custom or from other truck brand (DAF, Man, Mercedes,
+Renault, Scania or Volvo)) for your device to use as a second, independent dashboard
 . [See screenshots here](https://github.com/JAGFx/ets2-dashboard-skin/blob/master/doc/SKINS.md)
 
-I'm also introduce the possibility to change the unit of measurement as you
+I've also introduced the possibility to change the unit of measurement to what you
 prefer. [See the full list here](https://github.com/JAGFx/ets2-dashboard-skin/blob/master/doc/CONFIG_SETTINGS.md)
 
-A event overlay can also be configured !
+A event overlay can also be configured!
 
-Now, you've got a map integration !
+And now, a map integration!
 
-It's work on desktop and mobile browser.
+It works on both desktop and mobile browsers.
 
 ## Map
 
@@ -70,14 +68,14 @@ Available locales:
 
 ## Requirements
 
-- OS: Windows 64Bits
-- Game: Euro Truck Simulator 2
+- OS: Windows 64-bit
+- Game: Euro Truck Simulator 2 or American Truck Simulator
 - SCS SDK plugin: v1.11
-- Web-browser: Chrome (Desktop and Mobile), Firefox (Desktop dans Mobile), Edge ( Desktop and mobile )
+- Web-browser: Chrome (Desktop and Mobile), Firefox (Desktop and Mobile), Edge (Desktop and Mobile), Safari (Desktop and Mobile
 
 **Important: It dosen't work with all Internet Explorer browsers**
 
-## How to use ?
+## Usage instructions
 
 ### Prerequisite
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,9 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+		<meta name="apple-mobile-web-app-title" content="Dashboard">
+		<meta name="apple-mobile-web-app-capable" content="yes">
+		<meta name="apple-mobile-web-app-status-bar-style" content="gray">
 		<link rel="icon" href="<%= BASE_URL %>favicon.ico">
 		<link href="icons/icons.css" rel="stylesheet">
 		<title>Euro Truck Simulator 2 dashboard</title>
@@ -11,7 +14,7 @@
 	<body>
 		<div id="app" class="container-fluid"></div>
 		<noscript>
-			<strong>We're sorry but client doesn't work properly without JavaScript enabled. Please enable it to
+			<strong>We're sorry, but the client doesn't work properly without JavaScript enabled. Please enable it to
 				continue.</strong>
 		</noscript>
 	

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 		<meta name="apple-mobile-web-app-title" content="Dashboard">
 		<meta name="apple-mobile-web-app-capable" content="yes">
-		<meta name="apple-mobile-web-app-status-bar-style" content="gray">
+		<meta name="apple-mobile-web-app-status-bar-style" content="black">
 		<link rel="icon" href="<%= BASE_URL %>favicon.ico">
 		<link href="icons/icons.css" rel="stylesheet">
 		<title>Euro Truck Simulator 2 dashboard</title>


### PR DESCRIPTION
# Description
This PR adds support for iOS/iPadOS’s [documented Safari features](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html) and cleans up some of the English.
## Type of change

Please delete options that are not relevant.

- [x] Feature addition & English cleanup

# How Has This Been Tested?

__Complete if applicable.__

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] N/A yet, will test in a few hours

# Configuration

## Games

- [x] Euro truck simulator 2
- [x] American truck simulator

**Game version:**

- Euro truck simulator 2: [e.g. 1.40.5.13]
- American truck simulator: [e.g. 1.40.5.13]

## Context

__Complete if applicable.__

**Desktop:**

- OS: [e.g. iOS] Windows 11
- Browser [e.g. chrome, safari] N/A
- Version [e.g. 22] N/A

**Smartphone:**

- Device: [e.g. iPhone6] iPad 6 w/ Wifi
- OS: [e.g. iOS8.1] iOS 15
- Browser [e.g. stock browser, safari] Safari
- Version [e.g. 22] Unknown

**Additional information:**

- Skin name: [e.g. JAGFx]
- Dashboard version: [e.g. v1.2.1]
- SCS Telemetry version: [e.g. 1.10.5]
- Node version: [e.g. node14]
Irr.
# Checklist:

- [x] I have performed a self-review of my own code
- [x] The map tiles are correct and haven't any artefact or missing roads, prefab or other things like this
- [N/A] I've got attached the full map (level 0) on this pull request
- [N/A] I've got attached archive for **Euro truck simulator 2** and **American truck simulator** on this pull request